### PR TITLE
hide filename in swupdate error message so user can see entire message

### DIFF
--- a/recipes-core/recovery/recovery-initramfs/recovery-initramfs-init
+++ b/recipes-core/recovery/recovery-initramfs/recovery-initramfs-init
@@ -303,7 +303,9 @@ check_swu_package() {
 	fi
 
 	if [ "$?" != "0" ]; then
-		quit_with_error "Invalid update package ${1}"
+        # Don't include the filename in the error message, it wont wrap and the user wont be able to see the words 
+        # "Invalid update package"
+		quit_with_error "Invalid update package"
 	fi
 }
 


### PR DESCRIPTION
The update script displays error messages on the LCD display, but it doesn't wrap lines that are too long. Our users don't need to see the filename of the update file, and removing it from the error message keeps the important part of the error on the screen.