### PR TITLE
add openssl command line program to verify SWU packages

### DIFF
--- a/recipes-core/images/hqseries-portable-image.bb
+++ b/recipes-core/images/hqseries-portable-image.bb
@@ -85,6 +85,7 @@ IMAGE_INSTALL += " \
     umtp \
     htop \
     mtd-utils \
+    openssl-bin \
 "
 
 # Add predefined runtime package groups.


### PR DESCRIPTION
This adds the /usr/bin/openssl program that's used for verifying SWU packages. It's about 500KB.