### PR TITLE
Bump Digi SHAs per PCN 250117-02 for DDR clock source stability.

### DIFF
--- a/recipes-bsp/u-boot/u-boot-dey_2017.03.bbappend
+++ b/recipes-bsp/u-boot/u-boot-dey_2017.03.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}-${PV}:"
 
-SRCREV = "1ef810133fcecacf14e09155bee10aa66fc6ade7"
+SRCREV = "76d748841eb363555ff67a7160b7bc8d0f51acb8"
 
 SRC_URI_append = " \
     file://0001-Added-custom-r1701-platform.patch \

--- a/recipes-kernel/linux/linux-dey_4.14.bbappend
+++ b/recipes-kernel/linux/linux-dey_4.14.bbappend
@@ -10,7 +10,7 @@ SRC_URI = " \
 # Using special version of Linux. See git log for why.. see the fixes they have done. We need those.
 LOCALVERSION = "-dey"
 SRCBRANCH = "v4.14/dey-2.6/maint"
-SRCREV = "8dbae0c90779edf86a76487738b7d85cd6d1d615"
+SRCREV = "761bac6ff9eadb90c1acacdb120b749de7e724b1"
 
 SRC_URI_append = " \
     file://0001-Adding-hach-r1701-as-carrier-board-in-to-OTP-kernel.patch \


### PR DESCRIPTION
See https://github.com/digi-embedded/linux/commits/v4.14/dey-2.6/maint & https://github.com/digi-embedded/u-boot/commit/76d748841eb363555ff67a7160b7bc8d0f51acb8